### PR TITLE
Use C++17 standard when compiling

### DIFF
--- a/ext/mini_phone/extconf.rb
+++ b/ext/mini_phone/extconf.rb
@@ -39,7 +39,7 @@ end
 
 dir_config('mini_phone')
 
-$CXXFLAGS += ' -std=c++14 -ofast '
+$CXXFLAGS += ' -std=c++17 -ofast '
 
 create_makefile('mini_phone/mini_phone')
 


### PR DESCRIPTION
On macOS, using `libphonenumber` `8.13.6_1` in combination with `abseil` `20230125.1`, `mini_phone` does not want to compile anymore unless I change the C++ standard to C++17. Without it, a get a long list of errors:
```
Building native extensions with: '--with-ldflags=-Wl,-undefined,dynamic_lookup'
This could take a while...
ERROR:  Error installing mini_phone:
	ERROR: Failed to build gem native extension.

    current directory: /Users/remco/.rvm/gems/ruby-3.1.3/gems/mini_phone-1.1.8/ext/mini_phone
/Users/remco/.rvm/rubies/ruby-3.1.3/bin/ruby -I /Users/remco/.rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0 extconf.rb --with-ldflags\=-Wl,-undefined,dynamic_lookup
checking for -lphonenumber... yes
creating Makefile

current directory: /Users/remco/.rvm/gems/ruby-3.1.3/gems/mini_phone-1.1.8/ext/mini_phone
make DESTDIR\= sitearchdir\=./.gem.20230301-2545-xnf2dk sitelibdir\=./.gem.20230301-2545-xnf2dk clean

current directory: /Users/remco/.rvm/gems/ruby-3.1.3/gems/mini_phone-1.1.8/ext/mini_phone
make DESTDIR\= sitearchdir\=./.gem.20230301-2545-xnf2dk sitelibdir\=./.gem.20230301-2545-xnf2dk
compiling mini_phone.cc
In file included from mini_phone.cc:4:
In file included from /opt/homebrew/include/phonenumbers/phonenumberutil.h:33:
In file included from /opt/homebrew/include/absl/container/node_hash_set.h:42:
In file included from /opt/homebrew/include/absl/container/internal/hash_function_defaults.h:55:
In file included from /opt/homebrew/include/absl/hash/hash.h:85:
In file included from /opt/homebrew/include/absl/hash/internal/hash.h:48:
In file included from /opt/homebrew/include/absl/container/fixed_array.h:50:
In file included from /opt/homebrew/include/absl/container/internal/compressed_tuple.h:40:
/opt/homebrew/include/absl/utility/utility.h:164:12: error: no member named 'in_place_t' in namespace 'std'
using std::in_place_t;
      ~~~~~^
/opt/homebrew/include/absl/utility/utility.h:165:12: error: no member named 'in_place' in namespace 'std'
using std::in_place;
      ~~~~~^
/opt/homebrew/include/absl/utility/utility.h:181:12: error: no member named 'in_place_type' in namespace 'std'
using std::in_place_type;
      ~~~~~^
/opt/homebrew/include/absl/utility/utility.h:182:12: error: no member named 'in_place_type_t' in namespace 'std'
using std::in_place_type_t;
      ~~~~~^
/opt/homebrew/include/absl/utility/utility.h:198:12: error: no member named 'in_place_index' in namespace 'std'
using std::in_place_index;
      ~~~~~^
/opt/homebrew/include/absl/utility/utility.h:199:12: error: no member named 'in_place_index_t' in namespace 'std'
using std::in_place_index_t;
      ~~~~~^
In file included from mini_phone.cc:4:
In file included from /opt/homebrew/include/phonenumbers/phonenumberutil.h:33:
In file included from /opt/homebrew/include/absl/container/node_hash_set.h:42:
In file included from /opt/homebrew/include/absl/container/internal/hash_function_defaults.h:55:
In file included from /opt/homebrew/include/absl/hash/hash.h:85:
In file included from /opt/homebrew/include/absl/hash/internal/hash.h:48:
In file included from /opt/homebrew/include/absl/container/fixed_array.h:50:
/opt/homebrew/include/absl/container/internal/compressed_tuple.h:107:36: error: no type named 'in_place_t' in namespace 'absl'
  explicit constexpr Storage(absl::in_place_t, V&& v)
                             ~~~~~~^
/opt/homebrew/include/absl/container/internal/compressed_tuple.h:120:36: error: no type named 'in_place_t' in namespace 'absl'
  explicit constexpr Storage(absl::in_place_t, V&& v)
                             ~~~~~~^
/opt/homebrew/include/absl/container/internal/compressed_tuple.h:143:48: error: no type named 'in_place_t' in namespace 'absl'
  explicit constexpr CompressedTupleImpl(absl::in_place_t, Vs&&... args)
                                         ~~~~~~^
/opt/homebrew/include/absl/container/internal/compressed_tuple.h:144:24: error: no member named 'in_place' in namespace 'absl'; did you mean 'isspace'?
      : Storage<Ts, I>(absl::in_place, absl::forward<Vs>(args))... {}
                       ^~~~~~~~~~~~~~
                       isspace
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_ctype.h:267:1: note: 'isspace' declared here
isspace(int _c)
^
In file included from mini_phone.cc:4:
In file included from /opt/homebrew/include/phonenumbers/phonenumberutil.h:33:
In file included from /opt/homebrew/include/absl/container/node_hash_set.h:42:
In file included from /opt/homebrew/include/absl/container/internal/hash_function_defaults.h:55:
In file included from /opt/homebrew/include/absl/hash/hash.h:85:
In file included from /opt/homebrew/include/absl/hash/internal/hash.h:48:
In file included from /opt/homebrew/include/absl/container/fixed_array.h:50:
/opt/homebrew/include/absl/container/internal/compressed_tuple.h:155:48: error: no type named 'in_place_t' in namespace 'absl'
  explicit constexpr CompressedTupleImpl(absl::in_place_t, Vs&&... args)
                                         ~~~~~~^
/opt/homebrew/include/absl/container/internal/compressed_tuple.h:156:31: error: no member named 'in_place' in namespace 'absl'; did you mean 'isspace'?
      : Storage<Ts, I, false>(absl::in_place, absl::forward<Vs>(args))... {}
                              ^~~~~~~~~~~~~~
                              isspace
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_ctype.h:267:1: note: 'isspace' declared here
isspace(int _c)
^
In file included from mini_phone.cc:4:
In file included from /opt/homebrew/include/phonenumbers/phonenumberutil.h:33:
In file included from /opt/homebrew/include/absl/container/node_hash_set.h:42:
In file included from /opt/homebrew/include/absl/container/internal/hash_function_defaults.h:55:
In file included from /opt/homebrew/include/absl/hash/hash.h:85:
In file included from /opt/homebrew/include/absl/hash/internal/hash.h:48:
In file included from /opt/homebrew/include/absl/container/fixed_array.h:50:
/opt/homebrew/include/absl/container/internal/compressed_tuple.h:242:46: error: no member named 'in_place' in namespace 'absl'; did you mean 'isspace'?
      : CompressedTuple::CompressedTupleImpl(absl::in_place, base...) {}
                                             ^~~~~~~~~~~~~~
                                             isspace
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_ctype.h:267:1: note: 'isspace' declared here
isspace(int _c)
^
In file included from mini_phone.cc:4:
In file included from /opt/homebrew/include/phonenumbers/phonenumberutil.h:33:
In file included from /opt/homebrew/include/absl/container/node_hash_set.h:42:
In file included from /opt/homebrew/include/absl/container/internal/hash_function_defaults.h:55:
In file included from /opt/homebrew/include/absl/hash/hash.h:85:
In file included from /opt/homebrew/include/absl/hash/internal/hash.h:48:
In file included from /opt/homebrew/include/absl/container/fixed_array.h:50:
/opt/homebrew/include/absl/container/internal/compressed_tuple.h:254:46: error: no member named 'in_place' in namespace 'absl'; did you mean 'isspace'?
      : CompressedTuple::CompressedTupleImpl(absl::in_place,
                                             ^~~~~~~~~~~~~~
                                             isspace
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_ctype.h:267:1: note: 'isspace' declared here
isspace(int _c)
^
In file included from mini_phone.cc:4:
In file included from /opt/homebrew/include/phonenumbers/phonenumberutil.h:33:
In file included from /opt/homebrew/include/absl/container/node_hash_set.h:42:
In file included from /opt/homebrew/include/absl/container/internal/hash_function_defaults.h:55:
In file included from /opt/homebrew/include/absl/hash/hash.h:85:
In file included from /opt/homebrew/include/absl/hash/internal/hash.h:55:
/opt/homebrew/include/absl/types/optional.h:48:12: error: no member named 'optional' in namespace 'std'
using std::optional;
      ~~~~~^
/opt/homebrew/include/absl/types/optional.h:49:12: error: no member named 'make_optional' in namespace 'std'
using std::make_optional;
      ~~~~~^
/opt/homebrew/include/absl/types/optional.h:50:12: error: no member named 'nullopt_t' in namespace 'std'; did you mean 'nullptr_t'?
using std::nullopt_t;
      ~~~~~^~~~~~~~~
           nullptr_t
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__nullptr:56:31: note: 'nullptr_t' declared here
    typedef decltype(nullptr) nullptr_t;
                              ^
In file included from mini_phone.cc:4:
In file included from /opt/homebrew/include/phonenumbers/phonenumberutil.h:33:
In file included from /opt/homebrew/include/absl/container/node_hash_set.h:42:
In file included from /opt/homebrew/include/absl/container/internal/hash_function_defaults.h:55:
In file included from /opt/homebrew/include/absl/hash/hash.h:85:
In file included from /opt/homebrew/include/absl/hash/internal/hash.h:55:
/opt/homebrew/include/absl/types/optional.h:51:12: error: no member named 'nullopt' in namespace 'std'
using std::nullopt;
      ~~~~~^
In file included from mini_phone.cc:4:
In file included from /opt/homebrew/include/phonenumbers/phonenumberutil.h:33:
In file included from /opt/homebrew/include/absl/container/node_hash_set.h:42:
In file included from /opt/homebrew/include/absl/container/internal/hash_function_defaults.h:55:
In file included from /opt/homebrew/include/absl/hash/hash.h:85:
In file included from /opt/homebrew/include/absl/hash/internal/hash.h:56:
/opt/homebrew/include/absl/types/variant.h:56:7: error: no member named 'get_if' in namespace 'std'; did you mean 'std::this_thread::get_id'?
using std::get_if;
      ^~~~~~~~~~~
      std::this_thread::get_id
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__threading_support:713:1: note: 'std::this_thread::get_id' declared here
get_id() _NOEXCEPT
^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make: *** [mini_phone.o] Error 1
```

Most missing symbols seem related to C++17, although I can not find a confirmation that C++17 would be strictly required by any library. Maybe this is a homebrew specific problem, not sure.

It would be nice if this could be incorperated in the gem. If you want to only enable this on macOS, please let me know.