### PR TITLE
Use std::string in rb_phone_number_area_code

### DIFF
--- a/ext/mini_phone/mini_phone.cc
+++ b/ext/mini_phone/mini_phone.cc
@@ -417,15 +417,15 @@ extern "C" VALUE rb_phone_number_area_code(VALUE self) {
   TypedData_Get_Struct(self, PhoneNumberInfo, &phone_number_info_type, phone_number_info);
 
   PhoneNumber *number = phone_number_info->phone_number;
-  string national_significant_number;
+  std::string national_significant_number;
   phone_util.GetNationalSignificantNumber(*number, &national_significant_number);
-  string area_code;
-  string subscriber_number;
+  std::string area_code;
+  std::string subscriber_number;
 
   int area_code_length = phone_util.GetLengthOfGeographicalAreaCode(*number);
   if (area_code_length > 0) {
     area_code = national_significant_number.substr(0, area_code_length);
-    subscriber_number = national_significant_number.substr(area_code_length, string::npos);
+    subscriber_number = national_significant_number.substr(area_code_length, std::string::npos);
   } else {
     area_code = "";
     subscriber_number = national_significant_number;


### PR DESCRIPTION
When installing `mini_phone` on macOS 15 (Sequoia) using `libphonenumber` version `8.13.46`, I get the following errors:

```
checking for -lphonenumber... yes
checking for -lprotobuf... yes
checking for whether -O3 is accepted as CPPFLAGS... yes
creating Makefile

current directory: /Users/user/.rvm/gems/ruby-3.3.5/gems/mini_phone-1.2.0/ext/mini_phone
make DESTDIR\= sitearchdir\=./.gem.20240930-25052-gju52q sitelibdir\=./.gem.20240930-25052-gju52q clean

current directory: /Users/user/.rvm/gems/ruby-3.3.5/gems/mini_phone-1.2.0/ext/mini_phone
make DESTDIR\= sitearchdir\=./.gem.20240930-25052-gju52q sitelibdir\=./.gem.20240930-25052-gju52q
compiling mini_phone.cc
mini_phone.cc:420:3: error: unknown type name 'string'; did you mean 'std::string'?
  420 |   string national_significant_number;
      |   ^~~~~~
      |   std::string
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/string.h:48:7: note: 'std::string' declared here
   48 | using string = basic_string<char>;
      |       ^
mini_phone.cc:422:3: error: unknown type name 'string'; did you mean 'std::string'?
  422 |   string area_code;
      |   ^~~~~~
      |   std::string
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/string.h:48:7: note: 'std::string' declared here
   48 | using string = basic_string<char>;
      |       ^
mini_phone.cc:423:3: error: unknown type name 'string'; did you mean 'std::string'?
  423 |   string subscriber_number;
      |   ^~~~~~
      |   std::string
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/string.h:48:7: note: 'std::string' declared here
   48 | using string = basic_string<char>;
      |       ^
mini_phone.cc:428:78: error: use of undeclared identifier 'string'; did you mean 'std::string'?
  428 |     subscriber_number = national_significant_number.substr(area_code_length, string::npos);
      |                                                                              ^~~~~~
      |                                                                              std::string
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/string.h:48:7: note: 'std::string' declared here
   48 | using string = basic_string<char>;
      |       ^
4 errors generated.
make: *** [mini_phone.o] Error 1
```

It seems that `rb_phone_number_area_code` function specifically does not use `std::string` everywhere and just uses `string`. I suspect that a macOS update somewhere does not allow this anymore, failing new installs.

Replacing `string` with `std::string` seems to solve the compiler issues.